### PR TITLE
Schema uses references instead of embedded documents

### DIFF
--- a/Server/Models/loc-point.js
+++ b/Server/Models/loc-point.js
@@ -15,6 +15,9 @@ var locPointSchema = new Schema({
     type: Date,
     default: Date.now
   }
+},
+{
+  noId: true
 });
 
 locPointSchema.index({ location: '2dsphere'});

--- a/Server/Models/trip.js
+++ b/Server/Models/trip.js
@@ -7,7 +7,8 @@ var VideoModel = require('./video').schema;
 var LocPointModel = require('./loc-point').schema;
 
 var tripSchema = new Schema({
-  destination: LocPointModel,
+  user_id: String,
+  destination: LocPointModel, //"destination": { "location": { "coordinates": [ -122.40906260000001(longitude), 37.783750399999995(latitude)] } }
   start_time: { type: Date, default: Date.now },
   overdue_time: Date,
   path: [ LocPointModel ],

--- a/Server/Models/user.js
+++ b/Server/Models/user.js
@@ -3,12 +3,12 @@ var ContactSchema = require('./contact.js').schema;
 var TripSchema = require('./trip.js').schema;
 
 var UserSchema = new mongoose.Schema({
-	user_id: String,
+	_id: String,
 	name: String,
 	phone: Number,
 	delay: Number,
 	contacts: [ContactSchema],
-	trips: [TripSchema]
+	trips: [ String ]
 });
 
 module.exports = mongoose.model("User", UserSchema);


### PR DESCRIPTION
#### What's this PR do?

It changes the schema to use references instead of embedded documents.  Also, the location points do not have Ids.
#### What are the important parts of the code?

Look at the schema documents at the `user_id` field in the `trip` schema.  In the `user` schema the trips collection is now a list of trip_id numbers instead trip objects.
#### How should this be tested by the reviewer?

Currently the created route is the only tested one.
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)

closes #26 
