### PR TITLE
create component and styling for slide to guardian view

### DIFF
--- a/Client/Src/components/create-trip-start.js
+++ b/Client/Src/components/create-trip-start.js
@@ -20,7 +20,7 @@ const SafetyButton = require('../Common/safety-confirmation');
 var calculateMidpoint = require('../helpers/calculate-midpoint');
 var calculateDistance = require('../helpers/calculate-distance');
 const styles = StyleSheet.create(require('../styles.js'));
-
+import SlideUp from './slide-up';
 
 const { width, height } = Dimensions.get('window');
 const ASPECT_RATIO = width / height;
@@ -220,18 +220,32 @@ export default class MapStart extends Component {
           </View>
         </View>
 
-      {/*This is the bar on the bottom of the page to navigate to guardian view*/}
-        <View style={{justifyContent: 'center',position: 'absolute', bottom: 0, alignItems: 'center', width: width, height: 20, backgroundColor: 'lightGray'}}>
-          <View style={[{alignSelf: 'center', top: 0, width: 100, backgroundColor: 'gray'}, stylesAlt.triangle]}></View>
-          <Text style={[styles.descriptionText, {width: width, bottom: 3, marginTop: 0, fontSize: 16, backgroundColor: 'transparent'}]}>{'Guardian'}</Text>
-          <TouchableOpacity
-            onPress={() => navigator.push({'name': 'settings', sceneConfig: 'FloatFromBottom'})}
-            style={[{justifyContent: 'center', bottom: 20, height: 40, width: width * .3, borderWidth: 0, backgroundColor: 'transparent', opacity: 0.3}]}>
-          </TouchableOpacity>
-        </View>
+        {/*<View style={{justifyContent: 'center',position: 'absolute', bottom: 0, alignItems: 'center', width: width, height: 20, backgroundColor: 'transparent'}}>
+                  <TouchableOpacity
+                    onPress={() => navigator.push({'name': 'settings', sceneConfig: 'FloatFromBottom'})}
+                    activeOpacity={0.7}
+                    style={[{flex: 0, justifyContent: 'center', bottom: 0, height: 60, width: width, borderWidth: 0, backgroundColor: 'transparent', opacity: 0.9}]}>
+                    <View style={[{alignSelf: 'center', top: -10, width: 100, backgroundColor: 'gray'}, stylesAlt.triangle]}></View>
+                    <View style={{alignSelf: 'center', bottom: 10, height: 20, width: width, backgroundColor: 'lightGray'}}></View>
+                    <Text style={[styles.descriptionText, {position: 'absolute', width: width, left: 0, bottom: 25, fontSize: 16, backgroundColor: 'transparent', opacity: 1}]}>{'Guardian'}</Text>
+                  </TouchableOpacity>
+                </View>*/}
+        <SlideUp
+          style={{
+            justifyContent: 'center',
+            position: 'absolute',
+            bottom: 0,
+            alignItems: 'center',
+            width: width,
+            height: 20,
+            backgroundColor: 'transparent'
+          }}
+          navigator={navigator}
+          nextScene='settings'
+          label='Guardian'
+          />
 
       </View>
     );
   }
 };
-

--- a/Client/Src/components/create-trip-start.js
+++ b/Client/Src/components/create-trip-start.js
@@ -220,26 +220,7 @@ export default class MapStart extends Component {
           </View>
         </View>
 
-        {/*<View style={{justifyContent: 'center',position: 'absolute', bottom: 0, alignItems: 'center', width: width, height: 20, backgroundColor: 'transparent'}}>
-                  <TouchableOpacity
-                    onPress={() => navigator.push({'name': 'settings', sceneConfig: 'FloatFromBottom'})}
-                    activeOpacity={0.7}
-                    style={[{flex: 0, justifyContent: 'center', bottom: 0, height: 60, width: width, borderWidth: 0, backgroundColor: 'transparent', opacity: 0.9}]}>
-                    <View style={[{alignSelf: 'center', top: -10, width: 100, backgroundColor: 'gray'}, stylesAlt.triangle]}></View>
-                    <View style={{alignSelf: 'center', bottom: 10, height: 20, width: width, backgroundColor: 'lightGray'}}></View>
-                    <Text style={[styles.descriptionText, {position: 'absolute', width: width, left: 0, bottom: 25, fontSize: 16, backgroundColor: 'transparent', opacity: 1}]}>{'Guardian'}</Text>
-                  </TouchableOpacity>
-                </View>*/}
         <SlideUp
-          style={{
-            justifyContent: 'center',
-            position: 'absolute',
-            bottom: 0,
-            alignItems: 'center',
-            width: width,
-            height: 20,
-            backgroundColor: 'transparent'
-          }}
           navigator={navigator}
           nextScene='settings'
           label='Guardian'

--- a/Client/Src/components/slide-up.js
+++ b/Client/Src/components/slide-up.js
@@ -1,0 +1,96 @@
+'use strict';
+
+import React, {
+  StyleSheet,
+  Component,
+  View,
+  Text,
+  Dimensions,
+  TouchableOpacity
+} from 'react-native';
+
+import { extend } from 'lodash';
+
+const { width, height } = Dimensions.get('window');
+// importing styles
+const styles = StyleSheet.create({
+  triangle: {
+    width:0,
+    height: 0,
+    backgroundColor: 'transparent',
+    borderStyle: 'solid',
+    borderLeftWidth: 60,
+    borderRightWidth: 60,
+    borderBottomWidth: 20,
+    borderLeftColor: 'transparent',
+    borderRightColor: 'transparent',
+    borderBottomColor: 'lightGray'
+  },
+  sliderTip: {
+    alignSelf: 'center',
+    top: -10,
+    width: 100,
+    backgroundColor: 'gray'
+  },
+  sliderBody: {
+    alignSelf: 'center',
+    bottom: 10,
+    height: 20,
+    width: width,
+    backgroundColor: 'lightGray'
+  },
+  sliderText: {
+    position: 'absolute',
+    textAlign: 'center',
+    width: width,
+    bottom: 25,
+    fontSize: 16,
+    backgroundColor: 'transparent'
+  },
+  sliderContainer: {
+    justifyContent: 'center',
+    position: 'absolute',
+    bottom: 0,
+    alignItems: 'center',
+    width: width,
+    height: 20,
+    backgroundColor: 'transparent'
+  },
+  slider: {
+    flex: 0,
+    justifyContent: 'center',
+    bottom: 0,
+    height: 60,
+    width: width,
+    borderWidth: 0,
+    backgroundColor: 'transparent'
+  }
+});
+
+
+export default class SlideUp extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const {
+      navigator,
+      nextScene,
+      label
+    } = this.props;
+
+    return (
+      <View style={styles.sliderContainer}>
+        <TouchableOpacity
+          onPress={() => navigator.push({'name': nextScene, sceneConfig: 'FloatFromBottom'})}
+          activeOpacity={0.7}
+          style={styles.slider}>
+          <View style={[styles.sliderTip, styles.triangle]}></View>
+          <View style={styles.sliderBody}></View>
+          <Text style={styles.sliderText}>{label}</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+}


### PR DESCRIPTION
#### What's this PR do?

Creates slide component to pull-up guardian mode.  The `create-trip` view now imports the component.
#### What are the important parts of the code?

Look at `slide-up` in components.  It exports a module that expects `navigator`, `nextScene`, and `label` so that it can appear on the bottom of the screen.
#### How should this be tested by the reviewer?

download the changes and load the app.  You should see the slider working as before.
#### Is any other information necessary to understand this?

This is part of a refactor effort.  Stylesheets have been created in the component but can be exported as needed.  Another slide, `slide-down` needs to be created to pop the view back.
#### Screenshots (if appropriate)

![simulator screen shot feb 1 2016 11 40 54 pm](https://cloud.githubusercontent.com/assets/1467882/12742740/50732eac-c93d-11e5-9082-949b1c9806cf.png)
